### PR TITLE
Atomic operation is now done properly

### DIFF
--- a/exporter_test.go
+++ b/exporter_test.go
@@ -21,18 +21,11 @@ import (
 type FakeHttpClient struct {
 	err          error
 	requestData  string
-	requestCount atomic.Value
+	requestCount uint32
 }
 
 func (c *FakeHttpClient) Do(req *http.Request) (*http.Response, error) {
-	var rc int
-	var ok bool
-
-	if rc, ok = c.requestCount.Load().(int); !ok {
-		panic("FakeHttpClient.requestCount should be of type int")
-	}
-
-	c.requestCount.Store(rc + 1)
+	atomic.AddUint32(&c.requestCount, 1)
 
 	data, err := io.ReadAll(req.Body)
 	defer req.Body.Close()
@@ -57,12 +50,7 @@ func (c *FakeHttpClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func newFakeHttpClient() *FakeHttpClient {
-	rc := atomic.Value{}
-	rc.Store(0)
-
-	return &FakeHttpClient{
-		requestCount: rc,
-	}
+	return &FakeHttpClient{}
 }
 
 func newTestExporter(httpClient *FakeHttpClient) *Exporter {
@@ -112,15 +100,8 @@ func Test_Success(t *testing.T) {
 		t.Fatalf("exporter error: %s", err)
 	}
 
-	var rc int
-	var ok bool
-
-	if rc, ok = httpClient.requestCount.Load().(int); !ok {
-		t.Fatal("Expected httpClient.requestCount to be of type int")
-	}
-
-	if rc != 1 {
-		t.Fatalf("expected HTTP request count to be 1 but receveived %d", rc)
+	if atomic.LoadUint32(&httpClient.requestCount) != 1 {
+		t.Fatalf("expected HTTP request count to be 1 but receveived %d", httpClient.requestCount)
 	}
 
 	if httpClient.err != nil {
@@ -177,15 +158,8 @@ func Test_Cancelled_Context(t *testing.T) {
 		t.Fatal("expected shutdown to throw a 'context deadline exceeded' error")
 	}
 
-	var rc int
-	var ok bool
-
-	if rc, ok = httpClient.requestCount.Load().(int); !ok {
-		t.Fatal("Expected httpClient.requestCount to be of type int")
-	}
-
-	if rc != 0 {
-		t.Fatalf("expected HTTP request count to be 0 but receveived %d", rc)
+	if atomic.LoadUint32(&httpClient.requestCount) != 0 {
+		t.Fatalf("expected HTTP request count to be 0 but receveived %d", httpClient.requestCount)
 	}
 
 	if httpClient.err != nil {


### PR DESCRIPTION
This PR implements the correct usage of atomic operations in comparison to the previously implemented (thanks a lot @sanojsubran !!!).

## Wrong code

```go
var rc int
var ok bool

// rc is loaded in an atomic operation. This is correct
if rc, ok = c.requestCount.Load().(int); !ok {
	panic("FakeHttpClient.requestCount should be of type int")
}

// !!!!! rc is incremented and passed to an atomic operation.
// *** The increment is not atomic ***
c.requestCount.Store(rc + 1)
```

## Fixed code

```go
// The increment is an atomic operation
atomic.AddUint32(&c.requestCount, 1)
```
